### PR TITLE
CI: Switch workflows from Ubicloud to GitHub runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   test:
     name: Test
-    runs-on: ubicloud-standard-4
+    runs-on: ubuntu-latest
     container:
       image: robnomad/crystal:dev-hoard
 
@@ -29,7 +29,7 @@ jobs:
 
   lint:
     name: Lint
-    runs-on: ubicloud-standard-4
+    runs-on: ubuntu-latest
     container:
       image: robnomad/crystal:dev-hoard
 
@@ -53,7 +53,7 @@ jobs:
 
   build:
     name: Build
-    runs-on: ubicloud-standard-4
+    runs-on: ubuntu-latest
     container:
       image: robnomad/crystal:dev-hoard
 


### PR DESCRIPTION
## Summary

This PR switches the CI workflows from Ubicloud runners back to GitHub's standard runners for improved reliability and ecosystem integration.

## Changes Made

### CI Workflow Updates (.github/workflows/ci.yml)
- **Test job**: `ubicloud-standard-4` → `ubuntu-latest`
- **Lint job**: `ubicloud-standard-4` → `ubuntu-latest`  
- **Build job**: `ubicloud-standard-4` → `ubuntu-latest`

### Maintained Consistency
- ✅ **Container image**: Continue using `robnomad/crystal:dev-hoard` for identical build environment
- ✅ **Build steps**: No changes to actual build, test, or lint processes
- ✅ **Dependencies**: Same shard dependencies and Crystal toolchain
- ✅ **Release workflow**: Already uses GitHub runners, now consistent across all workflows

## Benefits

### 🔧 **Improved Reliability**
- GitHub's mature runner infrastructure with high availability
- Better integration with GitHub's ecosystem and tooling
- Reduced potential for infrastructure-specific CI issues

### 🚀 **Consistency**  
- Aligns with release workflow that already uses `ubuntu-latest`
- Unified runner environment across all workflows
- Easier maintenance and troubleshooting

### 💰 **Cost Optimization**
- Leverages included GitHub Actions minutes for public repositories
- Reduces dependency on external runner infrastructure

## Testing

- ✅ **No functional changes**: Same container, same build environment, same processes
- ✅ **Workflow syntax**: Valid GitHub Actions syntax maintained
- ✅ **Container compatibility**: `robnomad/crystal:dev-hoard` works on GitHub runners

## Risk Assessment

**Low Risk Change:**
- Only changes runner infrastructure, not build logic
- Same containerized environment ensures identical behavior
- Easy rollback if any issues arise
- Release workflow already validates GitHub runner compatibility

🤖 Generated with [Claude Code](https://claude.ai/code)