### PR TITLE
CI/CD: Migrate GitHub Actions workflows to UbiCloud standard-2 instances

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   test:
     name: Test
-    runs-on: ubuntu-latest
+    runs-on: ubicloud-standard-2
     container:
       image: robnomad/crystal:dev-hoard
 
@@ -41,7 +41,7 @@ jobs:
 
   lint:
     name: Lint
-    runs-on: ubuntu-latest
+    runs-on: ubicloud-standard-2
     container:
       image: robnomad/crystal:dev-hoard
 
@@ -65,7 +65,7 @@ jobs:
 
   build:
     name: Build
-    runs-on: ubuntu-latest
+    runs-on: ubicloud-standard-2
     container:
       image: robnomad/crystal:dev-hoard
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ env:
 jobs:
   create-release:
     name: Create Release
-    runs-on: ubuntu-latest
+    runs-on: ubicloud-standard-2
     outputs:
       upload_url: ${{ steps.create_release.outputs.upload_url }}
 
@@ -29,7 +29,7 @@ jobs:
 
   build-and-upload:
     name: Build and Upload Assets
-    runs-on: ubuntu-latest
+    runs-on: ubicloud-standard-2
     needs: create-release
     container:
       image: crystallang/crystal:${{ env.CRYSTAL_VERSION }}
@@ -72,7 +72,7 @@ jobs:
 
   publish-docs:
     name: Publish Documentation
-    runs-on: ubuntu-latest
+    runs-on: ubicloud-standard-2
     needs: create-release
     container:
       image: crystallang/crystal:${{ env.CRYSTAL_VERSION }}


### PR DESCRIPTION
## Summary
- Migrate all GitHub Actions workflow jobs from ubuntu-latest to ubicloud-standard-2 runners
- Updates CI workflow (test, lint, build) and release workflow (create-release, build-and-upload, publish-docs)
- Maintains all existing container configurations and job dependencies

## Test plan
- [ ] Verify CI workflow runs successfully on ubicloud-standard-2 instances
- [ ] Confirm all jobs complete without errors
- [ ] Validate that container images still work properly on UbiCloud infrastructure
- [ ] Test release workflow functionality with new runner configuration

🤖 Generated with [Claude Code](https://claude.ai/code)